### PR TITLE
Fix registering using initial_upstream

### DIFF
--- a/templates/boundary_custom_data.sh.tpl
+++ b/templates/boundary_custom_data.sh.tpl
@@ -142,17 +142,17 @@ function generate_boundary_config {
   cat >$BOUNDARY_CONFIG_PATH <<EOF
 
 "worker" {
-	public_addr = "$addr" 
+	public_addr = "$addr"
 %{ if hcp_boundary_cluster_id == "" ~}
-	name = "$host"
   initial_upstreams = [
 %{ for ip in formatlist("%s",boundary_upstream) ~}
   "${ip}:${boundary_upstream_port}",
 %{ endfor ~}
   ]
-%{ else ~}
-  auth_storage_path = "$BOUNDARY_DIR_DATA"
 %{ endif ~}
+  # Auth storage backend is always required
+  auth_storage_path = "$BOUNDARY_DIR_DATA"
+
 
 %{ if enable_session_recording ~}
   recording_storage_path="$BOUNDARY_DIR_BSR"


### PR DESCRIPTION
## Description
This PR fixes two issues:
- `name` is not allowed when we register using controller issued token, which we do in this module.
- `auth_storage_path` is always required whatever we use `HCP cluster id` or `initial_upstream`

## Related issue


## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How has this been tested?
- Deployed using upstream (hop to another worker) and directly using and HCP Cluster ID

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
[Add any additional information or context about the PR here]
