### PR TITLE
For KMS auth name is mandatory and auth path storage should not be set

### DIFF
--- a/templates/boundary_custom_data.sh.tpl
+++ b/templates/boundary_custom_data.sh.tpl
@@ -108,6 +108,7 @@ function scrape_vm_info {
   VM_PRIVATE_IP=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip)
   VM_PUBLIC_IP=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
   VM_NAME=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/name)
+  log "[INFO]" "Detected VM name is '$VM_NAME'."
   log "[INFO]" "Detected VM private IP address is '$VM_PRIVATE_IP'."
 }
 

--- a/templates/boundary_custom_data.sh.tpl
+++ b/templates/boundary_custom_data.sh.tpl
@@ -230,7 +230,7 @@ function generate_boundary_config {
   # Name is mandatory for worker KMS auth
   name = "$VM_NAME"
 %{ else ~}
-  # Auth storage backend is always required unless it's KMS AUTH
+  # Auth storage backend is always required unless it's KMS auth
   auth_storage_path = "$BOUNDARY_DIR_DATA"
 %{ endif ~}
 

--- a/templates/boundary_custom_data.sh.tpl
+++ b/templates/boundary_custom_data.sh.tpl
@@ -240,7 +240,6 @@ function generate_boundary_config {
 %{ endif ~}
   tags ${worker_tags}
 
-
 }
 
 %{ if hcp_boundary_cluster_id != "" ~}


### PR DESCRIPTION
## Description
KMS worker auth led is not working as the name is mandatory and aslo auth storage path should not be set

## Related issue
[Link to the related issue (if applicable)]

## Type of change
- [ X] Bug fix (non-breaking change which fixes an issue)


## How has this been tested?
- Deploy worker using KMS auth registration

## Checklist
- [X ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

## Additional notes
[Add any additional information or context about the PR here]
